### PR TITLE
system.prop: Set max hw overlays and the API level that the device of…

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -2,12 +2,16 @@
 af.fast_track_multiplier=1
 audio_hal.force_voice_config=wide
 
+# GMS
+ro.product.first_api_level=22
+
 # Display
 ro.opengles.version=196610
 
 # HWC
 debug.hwc.force_gpu=1
 ro.sf.disable_triple_buffer=0
+debug.hwc.max_hw_overlays=6
 
 # Wifi
 wifi.interface=wlan0


### PR DESCRIPTION
…ficially launched with

Set the defined number of hw overlays from here (https://github.com/Exynos7580/android_hardware_samsung_slsi-cm_exynos7580/blob/lineage-15.1/libhwcmodule/ExynosHWCModule.h) in the common system.prop.

Picked from https://github.com/TeamNexus/android_device_samsung_zero-common/blob/nx-8.1/zero-common.prop